### PR TITLE
Import JSON Records from Kafka (from #24)

### DIFF
--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -269,7 +269,7 @@ set the number of characters in the VARCHAR type accordingly.
 
 When specifying ``RECORD_FORMAT=JSON`` the connector expects a valid UTF-8
 serialized JSON record per message. 
-When using ``ÀS_JSON_DOC=true``, the record is inserted as a whole and 
+When using ``AS_JSON_DOC=true``, the record is inserted as a whole and
 the table has to be [prepared for it](#json-preparation)
 
 If you choose to import certain fields from the json record, specify the 

--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -368,6 +368,7 @@ FROM SCRIPT KAFKA_CONSUMER WITH
   BOOTSTRAP_SERVERS   = 'kafka01.internal:9092,kafka02.internal:9093,kafka03.internal:9094'
   TOPIC_NAME          = 'CUSTOMERS'
   TABLE_NAME          = 'RETAIL.CUSTOMERS'
+  RECORD_FORMAT       = 'JSON'
   RECORD_FIELDS       = 'age,lastName,address'
   GROUP_ID            = 'exasol-kafka-udf-consumers';
 ```

--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -449,7 +449,7 @@ These are optional parameters with their default values.
   Registry][schema-registry] which stores Avro schemas as metadata. Schema
   Registry will be used to parse the Kafka topic Avro data schemas.
 
-* ``RECORD_FORMAT`` - One of [avro, json]. Tje default value is **avro**
+* ``RECORD_FORMAT`` - One of [avro, json]. The default value is **avro**.
 
 * ``RECORD_FIELDS`` - A comma separated list of fields to import from the
   source record. This can help when the structure of the avro is not under your

--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -307,7 +307,7 @@ CREATE OR REPLACE TABLE <schema_name>.<table_name> (
 Note that the ``RECORD_FIELDS`` parameter is required when inserting JSON into
 columns as the order of fields in json records is not deterministic.
 
-# Import From Kafka Cluster
+## Importing Avro Records
 
 Several property values are required to access the Kafka
 cluster when importing data from Kafka topics using the connector.
@@ -315,7 +315,7 @@ cluster when importing data from Kafka topics using the connector.
 You should provide these key-value parameters:
 
 - ``BOOTSTRAP_SERVERS``
-- ``SCHEMA_REGISTRY_URL`` (only when using avro)
+- ``SCHEMA_REGISTRY_URL``
 - ``TOPIC_NAME``
 - ``TABLE_NAME``
 

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaIntegrationTest.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaIntegrationTest.scala
@@ -1,16 +1,10 @@
 package com.exasol.cloudetl.kafka
 
-import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 import com.exasol.ExaIterator
 
-import io.confluent.kafka.serializers.KafkaAvroSerializer
 import net.manub.embeddedkafka.schemaregistry.EmbeddedKafka
-import org.apache.avro.AvroRuntimeException
-import org.apache.avro.Schema
-import org.apache.avro.specific.SpecificRecordBase
-import org.apache.kafka.common.serialization.Serializer
 import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.BeforeAndAfterEach
@@ -26,29 +20,22 @@ trait KafkaIntegrationTest
 
   var topic: String = _
   var properties: Map[String, String] = _
-  val schemaRegistryUrl = "http://localhost:6002"
+
   val bootstrapServers = "localhost:6001"
 
   val defaultProperties = Map(
     "BOOTSTRAP_SERVERS" -> bootstrapServers,
-    "SCHEMA_REGISTRY_URL" -> schemaRegistryUrl,
     "TABLE_NAME" -> "exasolTable"
   )
 
   def getTopic(): String =
     Random.alphanumeric.take(4).mkString
 
-  implicit val serializer: Serializer[AvroRecord] = {
-    val properties = Map("schema.registry.url" -> schemaRegistryUrl)
-    val serializer = new KafkaAvroSerializer()
-    serializer.configure(properties.asJava, false)
-    serializer.asInstanceOf[Serializer[AvroRecord]]
-  }
+  def additionalProperties: Map[String, String] = Map()
 
   override final def beforeEach(): Unit = {
     topic = getTopic()
-    properties = defaultProperties ++ Map("TOPIC_NAME" -> topic)
-    ()
+    properties = defaultProperties ++ additionalProperties ++ Map("TOPIC_NAME" -> topic)
   }
 
   override final def beforeAll(): Unit = {
@@ -77,47 +64,6 @@ trait KafkaIntegrationTest
     when(mockedIterator.getLong(2)).thenReturn(offsetsHead, offsetsTail: _*)
 
     mockedIterator
-  }
-
-  private[this] val avroRecordSchema =
-    new Schema.Parser().parse(
-      s"""|{
-          | "namespace": "com.exasol.cloudetl",
-          | "type": "record",
-          | "name": "AvroRecordSchemaForIT",
-          | "fields": [
-          |     {"name": "col_str", "type": "string"},
-          |     {"name": "col_int", "type": "int"},
-          |     {"name": "col_long", "type": "long"}
-          | ]
-          |}""".stripMargin
-    )
-
-  case class AvroRecord(var col_str: String, var col_int: Int, var col_long: Long)
-      extends SpecificRecordBase {
-    def this() = this("", 0, 0)
-
-    override def get(index: Int): AnyRef = index match {
-      case 0 => col_str
-      case 1 => col_int.asInstanceOf[AnyRef]
-      case 2 => col_long.asInstanceOf[AnyRef]
-      case _ => throw new AvroRuntimeException(s"Unknown index $index!")
-    }
-
-    override def put(index: Int, value: Any): Unit = index match {
-      case 0 =>
-        col_str = value match {
-          case (utf8: org.apache.avro.util.Utf8) => utf8.toString
-          case _                                 => value.asInstanceOf[String]
-        }
-      case 1 =>
-        col_int = value.asInstanceOf[Int]
-      case 2 =>
-        col_long = value.asInstanceOf[Long]
-      case _ => throw new AvroRuntimeException(s"Unknown index $index!")
-    }
-
-    override def getSchema(): Schema = avroRecordSchema
   }
 
 }

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroIT.scala
@@ -1,0 +1,68 @@
+package com.exasol.cloudetl.kafka
+
+import scala.jdk.CollectionConverters._
+
+import com.exasol.cloudetl.kafka.KafkaTopicDataImporterAvroIT.schemaRegistryUrl
+
+import io.confluent.kafka.serializers.KafkaAvroSerializer
+import org.apache.avro.{AvroRuntimeException, Schema}
+import org.apache.avro.specific.SpecificRecordBase
+import org.apache.kafka.common.serialization.Serializer
+
+class KafkaTopicDataImporterAvroIT extends KafkaIntegrationTest {
+
+  override def additionalProperties: Map[String, String] =
+    Map("SCHEMA_REGISTRY_URL" -> schemaRegistryUrl)
+
+  implicit val serializer: Serializer[AvroRecord] = {
+    val properties = Map("schema.registry.url" -> schemaRegistryUrl)
+    val serializer = new KafkaAvroSerializer()
+    serializer.configure(properties.asJava, false)
+    serializer.asInstanceOf[Serializer[AvroRecord]]
+  }
+}
+
+case class AvroRecord(var col_str: String, var col_int: Int, var col_long: Long)
+    extends SpecificRecordBase {
+
+  private[this] val avroRecordSchema =
+    new Schema.Parser().parse(
+      s"""|{
+          | "namespace": "com.exasol.cloudetl",
+          | "type": "record",
+          | "name": "AvroRecordSchemaForIT",
+          | "fields": [
+          |     {"name": "col_str", "type": "string"},
+          |     {"name": "col_int", "type": "int"},
+          |     {"name": "col_long", "type": "long"}
+          | ]
+          |}""".stripMargin
+    )
+
+  def this() = this("", 0, 0)
+
+  override def get(index: Int): AnyRef = index match {
+    case 0 => col_str
+    case 1 => col_int.asInstanceOf[AnyRef]
+    case 2 => col_long.asInstanceOf[AnyRef]
+    case _ => throw new AvroRuntimeException(s"Unknown index $index!")
+  }
+
+  override def put(index: Int, value: Any): Unit = index match {
+    case 0 =>
+      col_str = value match {
+        case (utf8: org.apache.avro.util.Utf8) => utf8.toString
+        case _                                 => value.asInstanceOf[String]
+      }
+    case 1 =>
+      col_int = value.asInstanceOf[Int]
+    case 2 =>
+      col_long = value.asInstanceOf[Long]
+    case _ => throw new AvroRuntimeException(s"Unknown index $index!")
+  }
+
+  override def getSchema(): Schema = avroRecordSchema
+}
+object KafkaTopicDataImporterAvroIT {
+  val schemaRegistryUrl = "http://localhost:6002"
+}

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToColumnsIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToColumnsIT.scala
@@ -1,17 +1,13 @@
 package com.exasol.cloudetl.kafka
 
-import java.lang.{Integer => JInt}
-import java.lang.{Long => JLong}
+import java.lang.{Integer => JInt, Long => JLong}
 
-import com.exasol.ExaDataTypeException
-import com.exasol.ExaMetadata
+import com.exasol.{ExaDataTypeException, ExaMetadata}
 
 import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{times, verify, when}
 
-class KafkaTopicDataImporterIT extends KafkaIntegrationTest {
+class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT {
 
   test("run emits records from starting initial offset") {
     createCustomTopic(topic)
@@ -121,5 +117,4 @@ class KafkaTopicDataImporterIT extends KafkaIntegrationTest {
     assert(msg.contains(s"Error consuming Kafka topic '$topic' data."))
     assert(msg.contains("It occurs for partition '0' in node '0' and vm"))
   }
-
 }

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToJsonIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToJsonIT.scala
@@ -9,7 +9,7 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
-class KafkaTopicDataImporterAsJsonIT extends KafkaIntegrationTest {
+class KafkaTopicDataImporterAvroToJsonIT extends KafkaTopicDataImporterAvroIT {
 
   test("run emits records from starting initial offset") {
     val newProperties = properties ++ Map(

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToColumnsIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToColumnsIT.scala
@@ -1,0 +1,60 @@
+package com.exasol.cloudetl.kafka
+
+import java.lang.{Integer => JInt, Long => JLong}
+
+import com.exasol.ExaMetadata
+
+import org.apache.kafka.common.serialization.{Serializer, StringSerializer}
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito.{times, verify}
+
+class KafkaTopicDataImporterJsonToColumnsIT extends KafkaIntegrationTest {
+
+  implicit val serializer: Serializer[String] = new StringSerializer
+
+  override def additionalProperties: Map[String, String] =
+    Map("RECORD_FORMAT" -> "json", "RECORD_FIELDS" -> "col_str,col_int,col_object")
+
+  test("must deserialize json to exasol row") {
+    createCustomTopic(topic)
+    publishToKafka(
+      topic,
+      """
+        | {
+        |   "col_str": "val1",
+        |   "col_int": 11,
+        |   "col_ignore": "not_to_include",
+        |   "col_object": { "field": "value"}
+        |}""".stripMargin
+    )
+
+    publishToKafka(
+      topic,
+      """
+        | {
+        |   "col_str": "val2",
+        |   "col_int": 22,
+        |   "col_ignore": "not_to_include"
+        |}""".stripMargin
+    )
+
+    val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
+    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+
+    verify(iter, times(2)).emit(Seq(any[Object]): _*)
+    verify(iter, times(1)).emit(
+      "val1",
+      JInt.valueOf(11),
+      """{"field":"value"}""",
+      JInt.valueOf(0),
+      JLong.valueOf(0)
+    )
+    verify(iter, times(1)).emit(
+      "val2",
+      JInt.valueOf(22),
+      null,
+      JInt.valueOf(0),
+      JLong.valueOf(1)
+    )
+  }
+}

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToJsonIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToJsonIT.scala
@@ -1,0 +1,55 @@
+package com.exasol.cloudetl.kafka
+
+import java.lang.{Integer => JInt, Long => JLong}
+
+import com.exasol.ExaMetadata
+
+import org.apache.kafka.common.serialization.{Serializer, StringSerializer}
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito.{times, verify}
+
+class KafkaTopicDataImporterJsonToJsonIT extends KafkaIntegrationTest {
+
+  implicit val serializer: Serializer[String] = new StringSerializer
+
+  override def additionalProperties: Map[String, String] =
+    Map("RECORD_FORMAT" -> "json", "AS_JSON_DOC" -> "true")
+
+  test("must deserialize json to exasol row as full record") {
+    createCustomTopic(topic)
+
+    val inputRecord1 =
+      """
+        | {
+        |"col_str": "val1",
+        |"col_int": 11,
+        |"col_object": {"field": "value"}
+     }""".stripMargin
+
+    val inputRecord2 =
+      """
+        |{
+        |"col_str": "val2",
+        |"col_int": 22,
+        |"col_object": { "field": "value"}
+     }""".stripMargin
+
+    publishToKafka(topic, inputRecord1)
+    publishToKafka(topic, inputRecord2)
+
+    val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
+    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+
+    verify(iter, times(2)).emit(Seq(any[Object]): _*)
+    verify(iter, times(1)).emit(
+      inputRecord1,
+      JInt.valueOf(0),
+      JLong.valueOf(0)
+    )
+    verify(iter, times(1)).emit(
+      inputRecord2,
+      JInt.valueOf(0),
+      JLong.valueOf(1)
+    )
+  }
+}

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicMetadataReaderIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicMetadataReaderIT.scala
@@ -16,6 +16,9 @@ import org.mockito.Mockito._
 )
 class KafkaTopicMetadataReaderIT extends KafkaIntegrationTest {
 
+  override def additionalProperties: Map[String, String] =
+    Map("SCHEMA_REGISTRY_URL" -> KafkaTopicDataImporterAvroIT.schemaRegistryUrl)
+
   // Default case where Exasol table is empty.
   test("run emits default partitionId maxOffset pairs with single topic partition") {
     val iter = mockExasolIterator(properties, Seq(0), Seq(-1))

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
@@ -43,7 +43,11 @@ class KafkaConsumerProperties(private val properties: Map[String, String])
   final def getSingleColJson(): Boolean =
     isEnabled(AS_JSON_DOC)
 
-  final def getRecordType(): String = get(RECORD_FORMAT).getOrElse("avro")
+  /**
+   * Returns the type we expect on the kafka
+   * One of ['json', 'avro'] whereas 'avro is the default'
+   */
+  final def getRecordFormat(): String = get(RECORD_FORMAT).getOrElse("avro")
 
   final def getRecordFields(): Option[Seq[String]] =
     get(RECORD_FIELDS).map(_.split(",").map(_.trim)).map(_.toSeq)
@@ -188,7 +192,7 @@ class KafkaConsumerProperties(private val properties: Map[String, String])
     props.put(ENABLE_AUTO_COMMIT.kafkaPropertyName, ENABLE_AUTO_COMMIT.defaultValue)
     props.put(BOOTSTRAP_SERVERS.kafkaPropertyName, getBootstrapServers())
     props.put(GROUP_ID.kafkaPropertyName, getGroupId())
-    if ("avro".equals(getRecordType())) {
+    if ("avro".equals(getRecordFormat())) {
       props.put(SCHEMA_REGISTRY_URL.kafkaPropertyName, getSchemaRegistryUrl())
     }
     props.put(MAX_POLL_RECORDS.kafkaPropertyName, getMaxPollRecords())
@@ -373,6 +377,11 @@ object KafkaConsumerProperties extends CommonProperties {
    */
   private[kafka] final val RECORD_FIELDS: String = "RECORD_FIELDS"
 
+  /**
+   * The serialization format of the topic we are reading.
+   * Either avro serialized with the confluent schema registry or json as plain string
+   * Needed to construct the correct deserializer.
+   */
   private[kafka] final val RECORD_FORMAT: String = "RECORD_FORMAT"
 
   /**

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
@@ -44,8 +44,8 @@ class KafkaConsumerProperties(private val properties: Map[String, String])
     isEnabled(AS_JSON_DOC)
 
   /**
-   * Returns the type we expect on the kafka
-   * One of ['json', 'avro'] whereas 'avro is the default'
+   * Returns the type we expect on the Kafka.
+   * It is one of ['json', 'avro'] whereas 'avro' is the default.
    */
   final def getRecordFormat(): String = get(RECORD_FORMAT).getOrElse("avro")
 
@@ -379,8 +379,8 @@ object KafkaConsumerProperties extends CommonProperties {
 
   /**
    * The serialization format of the topic we are reading.
-   * Either avro serialized with the confluent schema registry or json as plain string
-   * Needed to construct the correct deserializer.
+   * Either avro serialized with the Confluent schema registry or json as plain string
+   * needed to construct the correct deserializer.
    */
   private[kafka] final val RECORD_FORMAT: String = "RECORD_FORMAT"
 

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporter.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporter.scala
@@ -43,7 +43,7 @@ object KafkaTopicDataImporter extends LazyLogging {
     val topic = kafkaProperties.getTopic()
     val topicPartition = new TopicPartition(topic, partitionId)
 
-    val recordDeserialization = kafkaProperties.getRecordType() match {
+    val recordDeserialization = kafkaProperties.getRecordFormat() match {
       case "avro" => AvroDeserialization
       case "json" => JsonDeserialization
     }

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaTopicMetadataReader.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaTopicMetadataReader.scala
@@ -10,6 +10,7 @@ import com.exasol.ExaIterator
 import com.exasol.ExaMetadata
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.kafka.common.serialization.VoidDeserializer
 
 /**
  * The object class that is referenced in the UDF scripts.
@@ -32,7 +33,7 @@ object KafkaTopicMetadataReader extends LazyLogging {
       seenPartitionOffsets += (partitionId -> partitionOffset)
     } while (iterator.next())
 
-    val kafkaConsumer = KafkaConsumerFactory(kafkaProperties, metadata)
+    val kafkaConsumer = KafkaConsumerFactory(kafkaProperties, new VoidDeserializer, metadata)
     val topicPartitions = kafkaConsumer.partitionsFor(topic).asScala.toList.map(_.partition())
     logger.info(s"Reading metadata for '${topicPartitions.mkString(",")}' topic partitions")
     try {

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/AvroDeserialization.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/AvroDeserialization.scala
@@ -8,7 +8,7 @@ import org.apache.kafka.common.serialization.Deserializer
 import scala.jdk.CollectionConverters.MapHasAsJava
 
 /**
- * Creates deserializers for avro records that are serialized with the confluent schema registry
+ * Creates deserializers for avro records that are serialized with the Confluent schema registry.
  */
 object AvroDeserialization extends RecordDeserialization {
 

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/AvroDeserialization.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/AvroDeserialization.scala
@@ -1,0 +1,46 @@
+package com.exasol.cloudetl.kafka.deserialization
+
+import com.exasol.cloudetl.kafka.{KafkaConnectorException, KafkaConsumerProperties}
+
+import io.confluent.kafka.serializers.{AbstractKafkaAvroSerDeConfig, KafkaAvroDeserializer}
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.common.serialization.Deserializer
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+/**
+ * Creates deserializers for avro records that are serialized with the confluent schema registry
+ */
+object AvroDeserialization extends RecordDeserialization {
+
+  override def getColumnDeserializer(
+    properties: KafkaConsumerProperties,
+    fields: Option[Seq[String]]
+  ): Deserializer[Seq[Any]] =
+    new GenericRecordDeserializer(fields, getAvroDeserializer(properties.getSchemaRegistryUrl()))
+
+  override def getSingleColumnJsonDeserializer(
+    properties: KafkaConsumerProperties,
+    fields: Option[Seq[String]]
+  ): Deserializer[Seq[Any]] =
+    if (properties.hasSchemaRegistryUrl()) {
+      new ToStringDeserializer(getAvroDeserializer(properties.getSchemaRegistryUrl()))
+    } else {
+      throw new KafkaConnectorException(
+        "SCHEMA_REGISTRY_URL must be provided for record type 'avro'"
+      )
+    }
+
+  private[this] def getAvroDeserializer(
+    schemaRegistryUrl: String
+  ): Deserializer[GenericRecord] = {
+    // The schema registry URL should be provided here since the one
+    // configured in consumer properties is not for the deserializer.
+    val deserializerConfig = Map(
+      AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG -> schemaRegistryUrl
+    )
+    val kafkaAvroDeserializer = new KafkaAvroDeserializer
+    kafkaAvroDeserializer.configure(deserializerConfig.asJava, false)
+    kafkaAvroDeserializer.asInstanceOf[Deserializer[GenericRecord]]
+  }
+
+}

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/GenericRecordDeserializer.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/GenericRecordDeserializer.scala
@@ -1,0 +1,34 @@
+package com.exasol.cloudetl.kafka.deserialization
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+import com.exasol.common.avro.AvroConverter
+
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.common.serialization.Deserializer
+
+/**
+ * Extract a set of fields from an Avro GenericRecord. If no field list is defined,
+ * all fields in the record are emitted.
+ *
+ */
+class GenericRecordDeserializer(
+  fieldList: Option[Seq[String]],
+  deserializer: Deserializer[GenericRecord]
+) extends Deserializer[Seq[Any]] {
+
+  private val converter = new AvroConverter()
+
+  final override def deserialize(topic: String, data: Array[Byte]): Seq[Any] = {
+    val record = deserializer.deserialize(topic, data)
+    val avroFields = record.getSchema.getFields.asScala
+    val fieldsToRead = fieldList
+      .map(_.map(filterField => Option(record.getSchema.getField(filterField))))
+      .getOrElse(avroFields.map(Option(_)))
+      .toSeq
+
+    fieldsToRead.map(
+      _.map(field => converter.convert(record.get(field.name()), field.schema())).orNull
+    )
+  }
+}

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/GenericRecordDeserializer.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/GenericRecordDeserializer.scala
@@ -10,7 +10,6 @@ import org.apache.kafka.common.serialization.Deserializer
 /**
  * Extract a set of fields from an Avro GenericRecord. If no field list is defined,
  * all fields in the record are emitted.
- *
  */
 class GenericRecordDeserializer(
   fieldList: Option[Seq[String]],
@@ -26,7 +25,6 @@ class GenericRecordDeserializer(
       .map(_.map(filterField => Option(record.getSchema.getField(filterField))))
       .getOrElse(avroFields.map(Option(_)))
       .toSeq
-
     fieldsToRead.map(
       _.map(field => converter.convert(record.get(field.name()), field.schema())).orNull
     )

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/JsonDeserialization.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/JsonDeserialization.scala
@@ -1,0 +1,37 @@
+package com.exasol.cloudetl.kafka.deserialization
+
+import com.exasol.cloudetl.kafka.{KafkaConnectorException, KafkaConsumerProperties}
+
+import org.apache.kafka.common.serialization.{Deserializer, StringDeserializer}
+
+/**
+ * Create deserializers for Json records
+ */
+object JsonDeserialization extends RecordDeserialization {
+
+  override def getSingleColumnJsonDeserializer(
+    properties: KafkaConsumerProperties,
+    fields: Option[Seq[String]]
+  ): Deserializer[Seq[Any]] = {
+
+    if (fields.isDefined) {
+      throw new KafkaConnectorException("""Specifying fields when dumping the Json into the DB
+                                          |is currently not supported""".stripMargin)
+    }
+    new ToStringDeserializer(new StringDeserializer)
+  }
+
+  override def getColumnDeserializer(
+    properties: KafkaConsumerProperties,
+    fields: Option[Seq[String]]
+  ): Deserializer[Seq[Any]] =
+    fields
+      .filter(_.nonEmpty)
+      .map(new JsonDeserializer(_, new StringDeserializer))
+      .getOrElse(
+        throw new KafkaConnectorException(
+          """Record format JSON requires RECORD_FIELDS to be set to a comma separated list
+           of fields to guarantee field order"""
+        )
+      )
+}

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/JsonDeserialization.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/JsonDeserialization.scala
@@ -5,7 +5,7 @@ import com.exasol.cloudetl.kafka.{KafkaConnectorException, KafkaConsumerProperti
 import org.apache.kafka.common.serialization.{Deserializer, StringDeserializer}
 
 /**
- * Create deserializers for Json records
+ * Creates deserializers for JSON records.
  */
 object JsonDeserialization extends RecordDeserialization {
 
@@ -13,7 +13,6 @@ object JsonDeserialization extends RecordDeserialization {
     properties: KafkaConsumerProperties,
     fields: Option[Seq[String]]
   ): Deserializer[Seq[Any]] = {
-
     if (fields.isDefined) {
       throw new KafkaConnectorException("""Specifying fields when dumping the Json into the DB
                                           |is currently not supported""".stripMargin)

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/JsonDeserializer.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/JsonDeserializer.scala
@@ -1,0 +1,39 @@
+package com.exasol.cloudetl.kafka.deserialization
+
+import com.exasol.cloudetl.kafka.deserialization.JsonDeserializer.objectMapper
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.JsonNodeType.{BOOLEAN, NUMBER, STRING}
+import org.apache.kafka.common.serialization.{Deserializer, StringDeserializer}
+
+class JsonDeserializer(
+  fields: Seq[String],
+  stringDeserializer: StringDeserializer
+) extends Deserializer[Seq[Any]] {
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  final override def deserialize(topic: String, data: Array[Byte]): Seq[Any] = {
+    val tree =
+      objectMapper.readTree(stringDeserializer.deserialize(topic, data))
+
+    fields
+      .map(
+        field =>
+          Option(tree.get(field))
+            .map(
+              jsonNode =>
+                jsonNode.getNodeType match {
+                  case STRING  => jsonNode.asText()
+                  case NUMBER  => jsonNode.numberValue()
+                  case BOOLEAN => jsonNode.asBoolean()
+                  case _       => jsonNode.toString
+              }
+            )
+            .orNull
+      )
+  }
+}
+
+object JsonDeserializer {
+  private val objectMapper = new ObjectMapper
+}

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/RecordDeserialization.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/RecordDeserialization.scala
@@ -1,0 +1,28 @@
+package com.exasol.cloudetl.kafka.deserialization
+
+import com.exasol.cloudetl.kafka.KafkaConsumerProperties
+
+import org.apache.kafka.common.serialization.Deserializer
+
+/**
+ * A factory dor kafka deserializers
+ */
+trait RecordDeserialization {
+
+  /**
+   * Create a deserializer that transforms the kafka record into a columnar structure.
+   * If a field list is provided, only those fields must be included in the seq
+   */
+  def getColumnDeserializer(
+    properties: KafkaConsumerProperties,
+    fields: Option[Seq[String]]
+  ): Deserializer[Seq[Any]]
+
+  /**
+   * Create a deserializer that emits the kafka record as a plain Json object
+   */
+  def getSingleColumnJsonDeserializer(
+    properties: KafkaConsumerProperties,
+    fields: Option[Seq[String]]
+  ): Deserializer[Seq[Any]]
+}

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/RecordDeserialization.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/RecordDeserialization.scala
@@ -5,13 +5,13 @@ import com.exasol.cloudetl.kafka.KafkaConsumerProperties
 import org.apache.kafka.common.serialization.Deserializer
 
 /**
- * A factory dor kafka deserializers
+ * A factory for Kafka deserializers.
  */
 trait RecordDeserialization {
 
   /**
-   * Create a deserializer that transforms the kafka record into a columnar structure.
-   * If a field list is provided, only those fields must be included in the seq
+   * Creates a deserializer that transforms the Kafka record into a columnar structure.
+   * If a field list is provided, only those fields must be included in the sequence.
    */
   def getColumnDeserializer(
     properties: KafkaConsumerProperties,
@@ -19,7 +19,7 @@ trait RecordDeserialization {
   ): Deserializer[Seq[Any]]
 
   /**
-   * Create a deserializer that emits the kafka record as a plain Json object
+   * Creates a deserializer that emits the Kafka record as a plain JSON object.
    */
   def getSingleColumnJsonDeserializer(
     properties: KafkaConsumerProperties,

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/ToStringDeserializer.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/ToStringDeserializer.scala
@@ -1,0 +1,11 @@
+package com.exasol.cloudetl.kafka.deserialization
+
+import org.apache.kafka.common.serialization.Deserializer
+
+/**
+ * Emits the string representation record as single element seq
+ */
+class ToStringDeserializer(delegate: Deserializer[_]) extends Deserializer[Seq[Any]] {
+  final override def deserialize(topic: String, data: Array[Byte]): Seq[Any] =
+    Seq(s"${delegate.deserialize(topic, data)}")
+}

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/ToStringDeserializer.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/ToStringDeserializer.scala
@@ -3,7 +3,7 @@ package com.exasol.cloudetl.kafka.deserialization
 import org.apache.kafka.common.serialization.Deserializer
 
 /**
- * Emits the string representation record as single element seq
+ * Emits the string representation record as single element sequence.
  */
 class ToStringDeserializer(delegate: Deserializer[_]) extends Deserializer[Seq[Any]] {
   final override def deserialize(topic: String, data: Array[Byte]): Seq[Any] =

--- a/src/test/scala/com/exasol/cloudetl/kafka/deserialization/GenericRecordDeserializerTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/kafka/deserialization/GenericRecordDeserializerTest.scala
@@ -1,0 +1,84 @@
+package com.exasol.cloudetl.kafka.deserialization
+
+import java.lang.{Integer => JInt}
+import java.util.Collections
+
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
+import org.apache.kafka.common.serialization.Deserializer
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.when
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+class GenericRecordDeserializerTest extends AnyFunSuite with Matchers with MockitoSugar {
+
+  private val schema = SchemaBuilder
+    .record("test")
+    .fields()
+    .optionalString("field1")
+    .requiredLong("field2")
+    .name("complex")
+    .`type`(SchemaBuilder.array().items().intType())
+    .withDefault(Collections.emptyList[JInt])
+    .endRecord()
+
+  private def extractFrom(
+    record: GenericRecord,
+    fieldList: Option[Seq[String]]
+  ): Seq[Any] = {
+    val derse = mock[Deserializer[GenericRecord]]
+    when(derse.deserialize(ArgumentMatchers.anyString(), ArgumentMatchers.any[Array[Byte]]))
+      .thenReturn(record)
+    new GenericRecordDeserializer(fieldList, derse).deserialize("", Array.empty[Byte])
+  }
+
+  test("Must give all fields from record if field list is not provided") {
+    val row = extractFrom(
+      new GenericRecordBuilder(schema)
+        .set("field1", "val1")
+        .set("field2", 11L)
+        .set("complex", Array(1, 2, 3))
+        .build(),
+      None
+    )
+
+    row must contain theSameElementsInOrderAs Seq("val1", 11L, """[1,2,3]""")
+  }
+
+  test("must only use fields provided to deserializer in the right order") {
+    val row = extractFrom(
+      new GenericRecordBuilder(schema)
+        .set("field1", "val1")
+        .set("field2", 11L)
+        .set("complex", Array(1, 2, 3))
+        .build(),
+      Option(Seq("complex", "field1"))
+    )
+
+    row must contain theSameElementsInOrderAs Seq("""[1,2,3]""", "val1")
+  }
+
+  test("must provide null values for fields not present and default values") {
+    val row = extractFrom(
+      new GenericRecordBuilder(schema)
+        .set("field2", 11L)
+        .build(),
+      Option(Seq("field1", "field2", "complex"))
+    )
+
+    row must contain theSameElementsInOrderAs Seq(null, 11L, "[]")
+  }
+
+  test("must return null for non-existent field to keep table structure") {
+    val row = extractFrom(
+      new GenericRecordBuilder(schema)
+        .set("field2", 11L)
+        .build(),
+      Option(Seq("field2", "unknownField"))
+    )
+
+    row must contain theSameElementsInOrderAs Seq(11L, null)
+  }
+}

--- a/src/test/scala/com/exasol/cloudetl/kafka/deserialization/GenericRecordDeserializerTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/kafka/deserialization/GenericRecordDeserializerTest.scala
@@ -34,7 +34,7 @@ class GenericRecordDeserializerTest extends AnyFunSuite with Matchers with Mocki
     new GenericRecordDeserializer(fieldList, derse).deserialize("", Array.empty[Byte])
   }
 
-  test("Must give all fields from record if field list is not provided") {
+  test("must give all fields from record if field list is not provided") {
     val row = extractFrom(
       new GenericRecordBuilder(schema)
         .set("field1", "val1")

--- a/src/test/scala/com/exasol/cloudetl/kafka/deserialization/JsonDeserializerTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/kafka/deserialization/JsonDeserializerTest.scala
@@ -1,0 +1,77 @@
+package com.exasol.cloudetl.kafka.deserialization
+
+import java.nio.charset.StandardCharsets
+
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
+
+class JsonDeserializerTest extends AnyFunSuite with Matchers {
+
+  test("must deserialize json record with primitives") {
+    val row = new JsonDeserializer(Seq("number", "string", "bool"), new StringDeserializer)
+      .deserialize(
+        "randomTopic",
+        """
+          |{
+          |  "number": 1,
+          |  "string": "hello",
+          |  "bool": true
+          |}""".stripMargin.getBytes(StandardCharsets.UTF_8)
+      )
+
+    row must contain theSameElementsInOrderAs Seq(1, "hello", true)
+  }
+
+  test("must convert complex json type to its string representation") {
+    val row = new JsonDeserializer(Seq("number", "record"), new StringDeserializer)
+      .deserialize(
+        "randomTopic",
+        """
+          |{
+          |  "number": 1,
+          |  "record": {
+          |   "field1": "value1",
+          |   "field2": 23
+          |   }
+          |}""".stripMargin.getBytes(StandardCharsets.UTF_8)
+      )
+
+    row must contain theSameElementsInOrderAs Seq(1, """{"field1":"value1","field2":23}""")
+  }
+
+  test("must only use fields provided to deserializer in the right order") {
+    val row = new JsonDeserializer(Seq("record", "number"), new StringDeserializer)
+      .deserialize(
+        "randomTopic",
+        """
+          |{
+          |  "number": 1,
+          |  "fieldToIgnore": {
+          |    "fieldA": 124,
+          |    "fieldB": [true]
+          |  },
+          |  "record": {
+          |   "field1": "value1",
+          |   "field2": 23
+          |   }
+          |}""".stripMargin.getBytes(StandardCharsets.UTF_8)
+      )
+
+    row must contain theSameElementsInOrderAs Seq("""{"field1":"value1","field2":23}""", 1)
+  }
+
+  test("must provide null values for fields not present") {
+    val row = new JsonDeserializer(Seq("number", "always_null_field"), new StringDeserializer)
+      .deserialize(
+        "randomTopic",
+        """
+          |{
+          |  "number": 1
+          |   }
+          |}""".stripMargin.getBytes(StandardCharsets.UTF_8)
+      )
+
+    row must contain theSameElementsInOrderAs Seq(1, null)
+  }
+}


### PR DESCRIPTION
This is a sketch on how to make this library import json records. The json conversion is rather basic as the main goal was to import the json as-is with the ``ÀS_JSON_DOC`` option, but the new ``RECORD_FIELDS`` option adds some value to the avro path as well: Right now a change in the record schema like field additions or removals or even a simple reordering of fields (which is possible) would break the import or just insert field values in the wrong columns.
