### PR TITLE
Allow the specification of the offset reset strategy

### DIFF
--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
@@ -37,7 +37,7 @@ class KafkaConsumerProperties(private val properties: Map[String, String])
 
   /**
    * Return the strategy to use when the last committed offset is empty or out of range.
-   * Defaults to <code>earliest{code}.
+   * Defaults to {@code earliest}.
    */
   final def getAutoOffsetReset(): String =
     get(AUTO_OFFSET_RESET.userPropertyName).fold(AUTO_OFFSET_RESET.defaultValue)(identity)

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaConsumerProperties.scala
@@ -36,6 +36,13 @@ class KafkaConsumerProperties(private val properties: Map[String, String])
     get(GROUP_ID.userPropertyName).fold(GROUP_ID.defaultValue)(identity)
 
   /**
+   * Return the strategy to use when the last committed offset is empty or out of range.
+   * Defaults to <code>earliest{code}.
+   */
+  final def getAutoOffsetReset(): String =
+    get(AUTO_OFFSET_RESET.userPropertyName).fold(AUTO_OFFSET_RESET.defaultValue)(identity)
+
+  /**
    * Returns user provided boolean,
    * if it is not provided by user
    * returns default value of false.
@@ -192,6 +199,7 @@ class KafkaConsumerProperties(private val properties: Map[String, String])
     props.put(ENABLE_AUTO_COMMIT.kafkaPropertyName, ENABLE_AUTO_COMMIT.defaultValue)
     props.put(BOOTSTRAP_SERVERS.kafkaPropertyName, getBootstrapServers())
     props.put(GROUP_ID.kafkaPropertyName, getGroupId())
+    props.put(AUTO_OFFSET_RESET.kafkaPropertyName, getAutoOffsetReset())
     if ("avro".equals(getRecordFormat())) {
       props.put(SCHEMA_REGISTRY_URL.kafkaPropertyName, getSchemaRegistryUrl())
     }
@@ -359,6 +367,19 @@ object KafkaConsumerProperties extends CommonProperties {
     "GROUP_ID",
     ConsumerConfig.GROUP_ID_CONFIG,
     "EXASOL_KAFKA_UDFS_CONSUMERS"
+  )
+
+  /**
+   * This is the {@code auto.offset.reset} configuration setting.
+   *
+   * This controls where the consumer starts when no previous offsets have been inserted in the
+   * table or the offset stored in the table is out of range in the partition.
+   * Defaults to {@code earliest}.
+   */
+  private[kafka] final val AUTO_OFFSET_RESET: Config[String] = Config[String](
+    "AUTO_OFFSET_RESET",
+    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+    "earliest"
   )
 
   /**

--- a/src/test/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/kafka/KafkaConsumerPropertiesTest.scala
@@ -180,6 +180,10 @@ class KafkaConsumerPropertiesTest extends AnyFunSuite with BeforeAndAfterEach wi
     assert(BaseProperties(properties).getMaxPartitionFetchBytes() === "1048576")
   }
 
+  test("getOffsetResetStrategy returns default value 'earliest' if property is not set") {
+    assert(BaseProperties(properties).getAutoOffsetReset() === "earliest")
+  }
+
   test("getSecurityProtocol returns user provided security protocol property value") {
     properties = Map("SECURITY_PROTOCOL" -> "SSL")
     assert(BaseProperties(properties).getSecurityProtocol() === "SSL")


### PR DESCRIPTION
When no previous offset is present (because it is the first load) or the last offset gathered from the table is out of range (because the last load was longer ago than the topic retention time), the connector always starts from the end of topic (kafka default strategy 'latest'). For low throughput topics there might be no message at that point of time so again, no new offset is stored and the messages are lost. Additionally, for topics that work with compaction it is expected to load everything from beginning the topic.

This commit allows specifying `AUTO_OFFSET_RESET` as property and the value is passed to the kafka consumer. The default setting is changed to `earliest` to prevent this behaviour. When one really wants to consume from the topic end, it can be overriden.