### PR TITLE
#39: Fixed bug related to consuming all offsets from stale topic

### DIFF
--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Releases
 
+* [1.2.1](changes_1.2.1.md)
 * [1.2.0](changes_1.2.0.md)
 * [1.1.0](changes_1.1.0.md)
 * [1.0.0](changes_1.0.0.md)

--- a/doc/changes/changes_1.2.1.md
+++ b/doc/changes/changes_1.2.1.md
@@ -1,0 +1,20 @@
+# Kafka Connector Extension 1.2.1, released 2021-XX-XX
+
+Code name: 
+
+## Summary
+
+
+## Bug Fixes
+
+* #41: Fixed failing consumer when Kafka topic offset resets
+
+### Runtime Dependency Updates
+
+* Updated `org.scala-lang.modules:scala-collection-compat:2.4.4` to `2.5.0`
+
+### Test Dependency Updates
+
+### Plugin Updates
+
+* Updated `org.wartremover:sbt-wartremover:2.4.15` to `2.4.16`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   private val ImportExportUDFVersion = "0.2.0"
   private val KafkaClientsVersion = "2.8.0"
   private val KafkaAvroSerializerVersion = "6.2.0"
-  private val ScalaCollectionCompatVersion = "2.4.4"
+  private val ScalaCollectionCompatVersion = "2.5.0"
 
   // Test dependencies versions
   private val ScalaTestVersion = "3.2.9"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.5.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // Adds a `wartremover` a flexible Scala code linting tool
 // http://github.com/puffnfresh/wartremover
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.15")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.16")
 
 // Adds Contrib Warts
 // http://github.com/wartremover/wartremover-contrib/

--- a/sbtx
+++ b/sbtx
@@ -34,8 +34,8 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.5.3"
-declare -r sbt_unreleased_version="1.5.3"
+declare -r sbt_release_version="1.5.5"
+declare -r sbt_unreleased_version="1.5.5"
 
 declare -r latest_213="2.13.6"
 declare -r latest_212="2.12.14"


### PR DESCRIPTION
When poll returns an empty result, fetch the current partition offset from Kafka instead of falling back to our own internal "latest" offset that we read from the topic at some point in the past.

This works around the case where, if we have a topic that used to have some records, but they were all expired, the consumer would keep looping infinitely.

It happens this way since the start and end offset of our empty-but-once-populated partition will be the same, 10 for example, but our *internal* latest offset is perhaps 5; and if no new records appear while we poll, we'll keep the '5', comparing it to the end offset of 10, forever assuming we need to read some more records.