### PR TITLE
Allow to use TIMESTAMP as output column type for Kafka message timestamp

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,9 +40,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sbt-cache-
 
-      - name: Check Formatting
-        run: sbt ++${{ matrix.scala }} scalafmtSbtCheck scalafmtCheckAll
-
       - name: Run CI
         run: ./scripts/ci.sh
         env:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         scala: [ 2.13.6 ]
-        exasol-docker-version: [ 6.2.15-d1, 7.0.11 ]
+        exasol-docker-version: [ 6.2.16-d1, 7.0.12, 7.1.0-d1 ]
 
     steps:
       - name: Checkout the Repository
@@ -44,18 +44,22 @@ jobs:
         run: ./scripts/ci.sh
         env:
           SCALA_VERSION: ${{ matrix.scala }}
+          EXASOL_DOCKER_VERSION: ${{ matrix.exasol-docker-version }}
 
       - name: Upload Coverage Results to Coveralls
-        run: sbt coveralls
+        run: sbt ++${{ matrix.scala }} coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # This required because of the sonarcloud-github-action docker volume mapping.
       - name: Prepare for Sonar Cloud Scan
+        if: startsWith(matrix.exasol-docker-version, '7.1')
         run: |
-          find . -name scoverage.xml -exec sed -i 's#/home/runner/work/kafka-connector-extension/kafka-connector-extension#/github/workspace#g' {} +
+          find . -name scoverage.xml -exec sed -i \
+          's#/home/runner/work/kafka-connector-extension/kafka-connector-extension#/github/workspace#g' {} +
 
       - name: Sonar Cloud Scan
+        if: startsWith(matrix.exasol-docker-version, '7.1')
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val root =
   project
     .in(file("."))
     .settings(moduleName := "exasol-kafka-connector-extension")
-    .settings(version := "1.3.0")
+    .settings(version := "1.3.1")
     .settings(orgSettings)
     .settings(buildSettings)
     .settings(Settings.projectSettings(scalaVersion))

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Releases
 
+* [1.3.1](changes_1.3.1.md)
 * [1.3.0](changes_1.3.0.md)
 * [1.2.1](changes_1.2.1.md)
 * [1.2.0](changes_1.2.0.md)

--- a/doc/changes/changes_1.3.1.md
+++ b/doc/changes/changes_1.3.1.md
@@ -7,7 +7,7 @@ Code name:
 ## Refactorings
 
 * #12: Added unified error codes
-* Added timestamp converter for long values (PR #50)
+* #51: Added timestamp converter for long values
 
 ## Dependency Updates
 
@@ -22,3 +22,6 @@ Code name:
 * Removed `org.testcontainers:kafka:1.16.0`
 
 ### Plugin Updates
+
+* Updated `com.eed3si9n:sbt-assembly:1.0.0` to `1.1.0`
+* Updated `net.bzzt:sbt-reproducible-builds:0.28` to `0.30`

--- a/doc/changes/changes_1.3.1.md
+++ b/doc/changes/changes_1.3.1.md
@@ -15,4 +15,10 @@ Code name:
 
 ### Test Dependency Updates
 
+* Updated `com.exasol:exasol-testcontainers:4.0.0` to `4.0.1`
+* Updated `org.mockito:mockito-core:3.11.2` to `3.12.4`
+* Added `com.sksamuel.avro4s:avro4s-core:4.0.10`
+* Added `io.confluent:kafka-streams-avro-serde:6.2.0`
+* Removed `org.testcontainers:kafka:1.16.0`
+
 ### Plugin Updates

--- a/doc/changes/changes_1.3.1.md
+++ b/doc/changes/changes_1.3.1.md
@@ -7,6 +7,7 @@ Code name:
 ## Refactorings
 
 * #12: Added unified error codes
+* Added timestamp converter for long values (PR #50)
 
 ## Dependency Updates
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,12 +15,11 @@ object Dependencies {
   // Test dependencies versions
   private val ScalaTestVersion = "3.2.9"
   private val ScalaTestPlusVersion = "1.0.0-M2"
-  private val MockitoCoreVersion = "3.11.2"
+  private val MockitoCoreVersion = "3.12.4"
   private val KafkaSchemaRegistryVersion = "6.2.0"
   private val ExasolTestDBBuilderVersion = "3.2.1"
-  private val ExasolTestContainersVersion = "4.0.0"
+  private val ExasolTestContainersVersion = "4.0.1"
   private val ExasolHamcrestMatcherVersion = "1.4.1"
-  private val TestContainersVersion = "1.16.0"
 
   val Resolvers: Seq[Resolver] = Seq(
     "jitpack.io" at "https://jitpack.io",
@@ -54,7 +53,8 @@ object Dependencies {
     "com.exasol" % "exasol-testcontainers" % ExasolTestContainersVersion,
     "com.exasol" % "test-db-builder-java" % ExasolTestDBBuilderVersion,
     "com.exasol" % "hamcrest-resultset-matcher" % ExasolHamcrestMatcherVersion,
-    "org.testcontainers" % "kafka" % TestContainersVersion
+    "io.confluent" % "kafka-streams-avro-serde" % KafkaAvroSerializerVersion,
+    "com.sksamuel.avro4s" %% "avro4s-core" % "4.0.10"
   ).map(_ % Test)
 
   lazy val AllDependencies: Seq[ModuleID] = RuntimeDependencies ++ TestDependencies

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover-contrib" % "1.3.12")
 // Adds a `assembly` task to create a fat JAR with all of its
 // dependencies
 // https://github.com/sbt/sbt-assembly
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 
 // Adds most common doc api mappings
 // https://github.com/ThoughtWorksInc/sbt-api-mappings
@@ -43,4 +43,4 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 // Adds a `sbt-reproducible-builds` plugin
 // https://github.com/raboof/sbt-reproducible-builds
-addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.28")
+addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -34,6 +34,15 @@ run_cleaning () {
   sbt ++$SCALA_VERSION clean assembly
 }
 
+run_formatting_checks () {
+  echo "############################################"
+  echo "#                                          #"
+  echo "#        ScalaFmt Checks                   #"
+  echo "#                                          #"
+  echo "############################################"
+  sbt ++$SCALA_VERSION scalafmtSbtCheck scalafmtCheckAll
+}
+
 run_unit_tests () {
   echo "############################################"
   echo "#                                          #"
@@ -117,6 +126,7 @@ run_clean_worktree_check () {
 
 run_self_check
 run_cleaning
+run_formatting_checks
 run_unit_tests
 run_integration_tests
 run_coverage_report

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToColumnsIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToColumnsIT.scala
@@ -11,6 +11,8 @@ import org.apache.kafka.clients.admin.RecordsToDelete
 import org.apache.kafka.common.TopicPartition
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{times, verify, when}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 
 class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT {
 
@@ -20,7 +22,22 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
     publishToKafka(topic, AvroRecord("hello", 4, 14))
 
     val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
-    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(5L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
+    KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)
     verify(iter, times(2)).emit(
@@ -68,7 +85,22 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
     publishToKafka(topic, AvroRecord("hello", 4, 14))
 
     val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
-    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(5L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
+    KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)
     verify(iter, times(2)).emit(
@@ -103,7 +135,22 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
 
     // records at 0, 1 are already read, committed
     val iter = mockExasolIterator(properties, Seq(0), Seq(1))
-    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(5L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
+    KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)
     verify(iter, times(2)).emit(
@@ -144,7 +191,22 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
 
     // comsumer in two batches each with 2 records
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(-1))
-    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(5L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
+    KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(4)).emit(Seq(any[Object]): _*)
     verify(iter, times(4)).emit(
@@ -168,7 +230,22 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
       publishToKafka(topic, AvroRecord(s"$i", i, i.toLong))
     }
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(-1))
-    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(5L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
+    KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(5)).emit(Seq(any[Object]): _*)
     verify(iter, times(5)).emit(
@@ -188,8 +265,23 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
     when(
       iter.emit("second", JInt.valueOf(3), JLong.valueOf(4), JInt.valueOf(0), JLong.valueOf(1))
     ).thenThrow(classOf[ExaDataTypeException])
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(5L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
     val thrown = intercept[KafkaConnectorException] {
-      KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+      KafkaTopicDataImporter.run(meta, iter)
     }
     val message = thrown.getMessage()
     assert(message.contains(s"Error consuming Kafka topic '$topic' data. "))

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToColumnsIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToColumnsIT.scala
@@ -22,22 +22,7 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
     publishToKafka(topic, AvroRecord("hello", 4, 14))
 
     val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
-    val meta = mock[ExaMetadata]
-    when(meta.getOutputColumnCount()).thenReturn(5L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
-    KafkaTopicDataImporter.run(meta, iter)
+    KafkaTopicDataImporter.run(getMockedMetadata(), iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)
     verify(iter, times(2)).emit(
@@ -85,22 +70,7 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
     publishToKafka(topic, AvroRecord("hello", 4, 14))
 
     val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
-    val meta = mock[ExaMetadata]
-    when(meta.getOutputColumnCount()).thenReturn(5L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
-    KafkaTopicDataImporter.run(meta, iter)
+    KafkaTopicDataImporter.run(getMockedMetadata(), iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)
     verify(iter, times(2)).emit(
@@ -135,22 +105,7 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
 
     // records at 0, 1 are already read, committed
     val iter = mockExasolIterator(properties, Seq(0), Seq(1))
-    val meta = mock[ExaMetadata]
-    when(meta.getOutputColumnCount()).thenReturn(5L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
-    KafkaTopicDataImporter.run(meta, iter)
+    KafkaTopicDataImporter.run(getMockedMetadata(), iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)
     verify(iter, times(2)).emit(
@@ -191,22 +146,7 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
 
     // comsumer in two batches each with 2 records
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(-1))
-    val meta = mock[ExaMetadata]
-    when(meta.getOutputColumnCount()).thenReturn(5L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
-    KafkaTopicDataImporter.run(meta, iter)
+    KafkaTopicDataImporter.run(getMockedMetadata(), iter)
 
     verify(iter, times(4)).emit(Seq(any[Object]): _*)
     verify(iter, times(4)).emit(
@@ -230,22 +170,7 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
       publishToKafka(topic, AvroRecord(s"$i", i, i.toLong))
     }
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(-1))
-    val meta = mock[ExaMetadata]
-    when(meta.getOutputColumnCount()).thenReturn(5L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
-    KafkaTopicDataImporter.run(meta, iter)
+    KafkaTopicDataImporter.run(getMockedMetadata(), iter)
 
     verify(iter, times(5)).emit(Seq(any[Object]): _*)
     verify(iter, times(5)).emit(
@@ -262,30 +187,32 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
     publishToKafka(topic, AvroRecord("first", 1, 2))
     publishToKafka(topic, AvroRecord("second", 3, 4))
     val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
-    when(
-      iter.emit("second", JInt.valueOf(3), JLong.valueOf(4), JInt.valueOf(0), JLong.valueOf(1))
-    ).thenThrow(classOf[ExaDataTypeException])
-    val meta = mock[ExaMetadata]
-    when(meta.getOutputColumnCount()).thenReturn(5L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
+    when(iter.emit("second", JInt.valueOf(3), JLong.valueOf(4), JInt.valueOf(0), JLong.valueOf(1)))
+      .thenThrow(classOf[ExaDataTypeException])
     val thrown = intercept[KafkaConnectorException] {
-      KafkaTopicDataImporter.run(meta, iter)
+      KafkaTopicDataImporter.run(getMockedMetadata(), iter)
     }
     val message = thrown.getMessage()
     assert(message.contains(s"Error consuming Kafka topic '$topic' data. "))
     assert(message.contains("It occurs for partition '0' in node '0' and vm"))
+  }
+
+  private[this] def getMockedMetadata(): ExaMetadata = {
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(5L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(new Answer[Class[_]]() {
+      override def answer(invocation: InvocationOnMock): Class[_] = {
+        val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+        Seq(
+          classOf[String],
+          classOf[JInt],
+          classOf[JLong],
+          classOf[JInt],
+          classOf[JLong]
+        )(columnIndex)
+      }
+    })
+    meta
   }
 
   private[this] def deleteRecordsFromTopic(topic: String, beforeOffset: Int): Unit = {
@@ -309,4 +236,5 @@ class KafkaTopicDataImporterAvroToColumnsIT extends KafkaTopicDataImporterAvroIT
     }
     ()
   }
+
 }

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToJsonIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToJsonIT.scala
@@ -23,20 +23,7 @@ class KafkaTopicDataImporterAvroToJsonIT extends KafkaTopicDataImporterAvroIT {
     publishToKafka(topic, AvroRecord("{'Value':'xyz'}", 5, 15))
 
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(-1))
-    val meta = mock[ExaMetadata]
-    when(meta.getOutputColumnCount()).thenReturn(3L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
-    KafkaTopicDataImporter.run(meta, iter)
+    KafkaTopicDataImporter.run(getMockedMetadata(), iter)
 
     verify(iter, times(3)).emit(Seq(any[Object]): _*)
     verify(iter, times(3)).emit(
@@ -74,20 +61,7 @@ class KafkaTopicDataImporterAvroToJsonIT extends KafkaTopicDataImporterAvroIT {
 
     // records at 0, 1 are already read, committed
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(1))
-    val meta = mock[ExaMetadata]
-    when(meta.getOutputColumnCount()).thenReturn(3L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
-    KafkaTopicDataImporter.run(meta, iter)
+    KafkaTopicDataImporter.run(getMockedMetadata(), iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)
     verify(iter, times(2)).emit(
@@ -122,20 +96,7 @@ class KafkaTopicDataImporterAvroToJsonIT extends KafkaTopicDataImporterAvroIT {
 
     // comsumer in two batches each with 2 records
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(-1))
-    val meta = mock[ExaMetadata]
-    when(meta.getOutputColumnCount()).thenReturn(3L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
-    KafkaTopicDataImporter.run(meta, iter)
+    KafkaTopicDataImporter.run(getMockedMetadata(), iter)
 
     verify(iter, times(4)).emit(Seq(any[Object]): _*)
     verify(iter, times(4)).emit(
@@ -144,4 +105,21 @@ class KafkaTopicDataImporterAvroToJsonIT extends KafkaTopicDataImporterAvroIT {
       anyLong().asInstanceOf[JLong]
     )
   }
+
+  private[this] def getMockedMetadata(): ExaMetadata = {
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(3L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(new Answer[Class[_]]() {
+      override def answer(invocation: InvocationOnMock): Class[_] = {
+        val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+        Seq(
+          classOf[String],
+          classOf[JInt],
+          classOf[JLong]
+        )(columnIndex)
+      }
+    })
+    meta
+  }
+
 }

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToJsonIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterAvroToJsonIT.scala
@@ -5,10 +5,11 @@ import java.lang.{Long => JLong}
 
 import com.exasol.ExaMetadata
 
-import org.mockito.{ArgumentCaptor, ArgumentMatchers}
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
+import org.mockito.Mockito.{times, verify, when}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 
 class KafkaTopicDataImporterAvroToJsonIT extends KafkaTopicDataImporterAvroIT {
 
@@ -22,7 +23,20 @@ class KafkaTopicDataImporterAvroToJsonIT extends KafkaTopicDataImporterAvroIT {
     publishToKafka(topic, AvroRecord("{'Value':'xyz'}", 5, 15))
 
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(-1))
-    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(3L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
+    KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(3)).emit(Seq(any[Object]): _*)
     verify(iter, times(3)).emit(
@@ -60,7 +74,20 @@ class KafkaTopicDataImporterAvroToJsonIT extends KafkaTopicDataImporterAvroIT {
 
     // records at 0, 1 are already read, committed
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(1))
-    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(3L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
+    KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)
     verify(iter, times(2)).emit(
@@ -95,7 +122,20 @@ class KafkaTopicDataImporterAvroToJsonIT extends KafkaTopicDataImporterAvroIT {
 
     // comsumer in two batches each with 2 records
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(-1))
-    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(3L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
+    KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(4)).emit(Seq(any[Object]): _*)
     verify(iter, times(4)).emit(

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToColumnsIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToColumnsIT.scala
@@ -45,19 +45,18 @@ class KafkaTopicDataImporterJsonToColumnsIT extends KafkaIntegrationTest {
     val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
     val meta = mock[ExaMetadata]
     when(meta.getOutputColumnCount()).thenReturn(5L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(new Answer[Class[_]]() {
+      override def answer(invocation: InvocationOnMock): Class[_] = {
+        val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+        Seq(
+          classOf[String],
+          classOf[JInt],
+          classOf[String],
+          classOf[JInt],
+          classOf[JLong]
+        )(columnIndex)
+      }
+    })
     KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToJsonIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToJsonIT.scala
@@ -43,17 +43,16 @@ class KafkaTopicDataImporterJsonToJsonIT extends KafkaIntegrationTest {
     val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
     val meta = mock[ExaMetadata]
     when(meta.getOutputColumnCount()).thenReturn(3L)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          Seq(
-            classOf[String],
-            classOf[JInt],
-            classOf[JLong],
-          )(columnIndex)
-        }
-      })
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(new Answer[Class[_]]() {
+      override def answer(invocation: InvocationOnMock): Class[_] = {
+        val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+        Seq(
+          classOf[String],
+          classOf[JInt],
+          classOf[JLong]
+        )(columnIndex)
+      }
+    })
     KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToJsonIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporterJsonToJsonIT.scala
@@ -3,10 +3,13 @@ package com.exasol.cloudetl.kafka
 import java.lang.{Integer => JInt, Long => JLong}
 
 import com.exasol.ExaMetadata
+
 import org.apache.kafka.common.serialization.{Serializer, StringSerializer}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito.{times, verify}
+import org.mockito.Mockito.{times, verify, when}
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 
 class KafkaTopicDataImporterJsonToJsonIT extends KafkaIntegrationTest {
 
@@ -38,7 +41,20 @@ class KafkaTopicDataImporterJsonToJsonIT extends KafkaIntegrationTest {
     publishToKafka(topic, inputRecord2)
 
     val iter = mockExasolIterator(properties, Seq(0), Seq(-1))
-    KafkaTopicDataImporter.run(mock[ExaMetadata], iter)
+    val meta = mock[ExaMetadata]
+    when(meta.getOutputColumnCount()).thenReturn(3L)
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(
+      new Answer[Class[_]]() {
+        override def answer(invocation: InvocationOnMock): Class[_] = {
+          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+          Seq(
+            classOf[String],
+            classOf[JInt],
+            classOf[JLong],
+          )(columnIndex)
+        }
+      })
+    KafkaTopicDataImporter.run(meta, iter)
 
     verify(iter, times(2)).emit(Seq(any[Object]): _*)
     verify(iter, times(1)).emit(

--- a/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicMetadataReaderIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/KafkaTopicMetadataReaderIT.scala
@@ -7,8 +7,7 @@ import com.exasol.ExaDataTypeException
 import com.exasol.ExaIterationException
 import com.exasol.ExaMetadata
 
-import org.mockito.ArgumentMatchers.anyInt
-import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 
 @SuppressWarnings(
@@ -64,7 +63,7 @@ class KafkaTopicMetadataReaderIT extends KafkaIntegrationTest {
     verify(iter, times(1)).emit(JInt.valueOf(1), JLong.valueOf(7))
   }
 
-  test("run throws if it cannot create KafkConsumer") {
+  test("run throws if it cannot create KafkaConsumer") {
     createCustomTopic(topic)
     val newProperties = properties + ("BOOTSTRAP_SERVERS" -> "kafka01.internal:9092")
     val iter = mockExasolIterator(newProperties, Seq(0), Seq(-1))

--- a/src/it/scala/com/exasol/cloudetl/kafka/RecordFieldSpecificationIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/RecordFieldSpecificationIT.scala
@@ -41,13 +41,12 @@ class RecordFieldSpecificationIT extends KafkaTopicDataImporterAvroIT {
     val columnCount = outputColumnTypesWithMeta.size
     val meta = mock[ExaMetadata]
     when(meta.getOutputColumnCount()).thenReturn(columnCount)
-    when(meta.getOutputColumnType(anyInt())).thenAnswer(
-      new Answer[Class[_]]() {
-        override def answer(invocation: InvocationOnMock): Class[_] = {
-          val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
-          outputColumnTypesWithMeta(columnIndex)
-        }
-      })
+    when(meta.getOutputColumnType(anyInt())).thenAnswer(new Answer[Class[_]]() {
+      override def answer(invocation: InvocationOnMock): Class[_] = {
+        val columnIndex = invocation.getArguments()(0).asInstanceOf[JInt]
+        outputColumnTypesWithMeta(columnIndex)
+      }
+    })
     KafkaTopicDataImporter.run(meta, iter)
 
     val captor = ArgumentCaptor.forClass[Any, Any](classOf[Any])
@@ -60,17 +59,13 @@ class RecordFieldSpecificationIT extends KafkaTopicDataImporterAvroIT {
   test("default must be 'value.*': All fields from the record") {
     createCustomTopic(topic)
     publishToKafka(topic, customRecord)
-    assert(
-      getEmittedValues("value.*", Seq(classOf[String], classOf[JInt], classOf[JLong])
-    ) === Seq("abc", 3, 13))
+    assert(getEmittedValues("value.*", Seq(classOf[String], classOf[JInt], classOf[JLong])) === Seq("abc", 3, 13))
   }
 
   test("must emit multiple record value fields in the order specified") {
     createCustomTopic(topic)
     publishToKafka(topic, customRecord)
-    assert(
-      getEmittedValues("value.col_long, value.col_str", Seq(classOf[JLong], classOf[String])
-      ) === Seq(13, "abc"))
+    assert(getEmittedValues("value.col_long, value.col_str", Seq(classOf[JLong], classOf[String])) === Seq(13, "abc"))
   }
 
   test("must be able to reference the full value") {
@@ -92,9 +87,7 @@ class RecordFieldSpecificationIT extends KafkaTopicDataImporterAvroIT {
   test("must be able to reference key values with default RECORD_KEY_FORMAT string") {
     createCustomTopic(topic)
     publishToKafka(topic, "string_key", customRecord)
-    assert(
-      getEmittedValues("key, value.col_long", Seq(classOf[String], classOf[JLong])
-      ) === Seq("string_key", 13))
+    assert(getEmittedValues("key, value.col_long", Seq(classOf[String], classOf[JLong])) === Seq("string_key", 13))
   }
 
   test("must fail when the key is accessed with concrete field") {

--- a/src/it/scala/com/exasol/cloudetl/kafka/docker/BaseDockerIntegrationTest.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/docker/BaseDockerIntegrationTest.scala
@@ -16,7 +16,7 @@ import org.scalatest.funsuite.AnyFunSuite
 trait BaseDockerIntegrationTest extends AnyFunSuite with BeforeAndAfterAll {
   private[this] val JAR_DIRECTORY_PATTERN = "scala-"
   private[this] val JAR_NAME_PATTERN = "exasol-kafka-connector-extension-"
-  private[this] val DEFAULT_EXASOL_DOCKER_IMAGE = "7.0.10"
+  private[this] val DEFAULT_EXASOL_DOCKER_IMAGE = "7.1.0-d1"
 
   val network = DockerNamedNetwork("kafka-it-tests", true)
   val exasolContainer = {

--- a/src/it/scala/com/exasol/cloudetl/kafka/docker/BaseDockerIntegrationTest.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/docker/BaseDockerIntegrationTest.scala
@@ -123,7 +123,13 @@ trait BaseDockerIntegrationTest extends AnyFunSuite with BeforeAndAfterAll {
     }
   }
 
-  private[this] def getExasolDockerImageVersion(): String =
-    System.getProperty("EXASOL_DOCKER_VERSION", DEFAULT_EXASOL_DOCKER_IMAGE)
+  private[this] def getExasolDockerImageVersion(): String = {
+    val dockerVersion = System.getenv("EXASOL_DOCKER_VERSION")
+    if (dockerVersion == null) {
+      DEFAULT_EXASOL_DOCKER_IMAGE
+    } else {
+      dockerVersion
+    }
+  }
 
 }

--- a/src/it/scala/com/exasol/cloudetl/kafka/docker/BaseKafkaDockerIntegrationTest.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/docker/BaseKafkaDockerIntegrationTest.scala
@@ -3,6 +3,9 @@ package com.exasol.cloudetl.kafka
 import java.util.List
 import java.util.Map
 import java.util.concurrent.TimeUnit
+import java.util.stream.Stream
+
+import com.exasol.cloudetl.kafka.serde._
 
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -11,20 +14,22 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
 import org.testcontainers.containers.Container
 import org.testcontainers.containers.GenericContainer
-import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.lifecycle.Startables
 import org.testcontainers.utility.DockerImageName
 
 trait BaseKafkaDockerIntegrationTest extends BaseDockerIntegrationTest {
 
   private[this] val DEFAULT_CONFLUENT_PLATFORM_VERSION = "6.2.0"
   private[this] val ZOOKEEPER_PORT = 2181
+  private[this] val KAFKA_EXTERNAL_PORT = 29092
   private[this] val SCHEMA_REGISTRY_PORT = 8081
+  private[this] val ADMIN_TIMEOUT_MILLIS = 5000
+
   var adminClient: AdminClient = _
 
   val zookeeperContainer = {
-    val image = DockerImageName
-      .parse("confluentinc/cp-zookeeper")
-      .withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION)
+    val image = DockerImageName.parse("confluentinc/cp-zookeeper").withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION)
     val c: GenericContainer[_] = new GenericContainer(image)
     c.withNetwork(network)
     c.withNetworkAliases("zookeeper")
@@ -33,62 +38,50 @@ trait BaseKafkaDockerIntegrationTest extends BaseDockerIntegrationTest {
     c
   }
 
-  val schemaRegistryContainer = {
-    val image = DockerImageName
-      .parse("confluentinc/cp-schema-registry")
-      .withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION)
-    val c: GenericContainer[_] = new GenericContainer(image)
-    c.withNetwork(network)
-    c.withNetworkAliases("schema-registry")
-    c.withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
-    c.withEnv(
-      "SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL",
-      s"${zookeeperContainer.getHost()}:$ZOOKEEPER_PORT"
-    )
-    c.withReuse(true)
-    c
-  }
-
   val kafkaBrokerContainer = {
-    val image = DockerImageName
-      .parse("confluentinc/cp-kafka")
-      .withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION)
-    val c = new KafkaContainer(image)
-    c.withCreateContainerCmdModifier { case cmd =>
-      cmd.withHostName("kafka01")
-      ()
-    }
+    val image = DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION)
+    val c: GenericContainer[_] = new KafkaContainer(image, KAFKA_EXTERNAL_PORT)
     c.dependsOn(zookeeperContainer)
     c.withNetwork(network)
     c.withNetworkAliases("kafka01")
-    c.withExternalZookeeper(s"zookeeper:$ZOOKEEPER_PORT")
+    c.withEnv("KAFKA_ZOOKEEPER_CONNECT", s"zookeeper:$ZOOKEEPER_PORT")
     c.withEnv("KAFKA_BROKER_ID", "0")
+    c.withEnv("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT")
+    c.withEnv("KAFKA_LISTENERS", s"INTERNAL://0.0.0.0:9092,EXTERNAL://0.0.0.0:$KAFKA_EXTERNAL_PORT")
+    c.withEnv("KAFKA_ADVERTISED_LISTENERS", s"INTERNAL://kafka01:9092,EXTERNAL://127.0.0.1:$KAFKA_EXTERNAL_PORT")
+    c.withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "INTERNAL")
+    c.withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
+    c.withExtraHost("kafka01", "127.0.0.1")
     c.withReuse(true)
     c
   }
 
-  def getSchemaRegistryURL(): String = {
-    val schemaRegistryHost = getContainerNetworkAddress(schemaRegistryContainer)
-    val schemaRegistryPort = schemaRegistryContainer.getMappedPort(SCHEMA_REGISTRY_PORT)
-    s"http://$schemaRegistryHost:$schemaRegistryPort"
+  val schemaRegistryContainer = {
+    val image = DockerImageName.parse("confluentinc/cp-schema-registry").withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION)
+    val c: GenericContainer[_] = new SchemaRegistryContainer(image, SCHEMA_REGISTRY_PORT)
+    c.dependsOn(kafkaBrokerContainer)
+    c.withNetwork(network)
+    c.withNetworkAliases("schema-registry")
+    c.withEnv("SCHEMA_REGISTRY_HOST_NAME", "localhost")
+    c.withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka01:9092")
+    c.withEnv("SCHEMA_REGISTRY_KAFKASTORE_TOPIC_REPLICATION_FACTOR", "1")
+    c.withExposedPorts(SCHEMA_REGISTRY_PORT)
+    c.waitingFor(Wait.forHttp("/subjects").forStatusCode(200))
+    c.withReuse(true)
+    c
   }
 
-  def getBootstrapServers(): String = {
-    val brokerHost = getContainerNetworkAddress(kafkaBrokerContainer)
-    val brokerPort = kafkaBrokerContainer.getMappedPort(9093)
-    s"$brokerHost:$brokerPort"
-  }
+  def getExternalSchemaRegistryUrl(): String =
+    s"http://localhost:$SCHEMA_REGISTRY_PORT"
 
-  def prepareKafkaCluster(): Unit = {
+  def getExternalBootstrapServers(): String =
+    s"localhost:$KAFKA_EXTERNAL_PORT"
+
+  def setupAdminClient(): Unit = {
     val properties: Map[String, Object] =
-      Map.of(
-        AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
-        kafkaBrokerContainer.getBootstrapServers()
-      )
+      Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, getExternalBootstrapServers())
     adminClient = AdminClient.create(properties)
   }
-
-  private[this] val ADMIN_TIMEOUT_MILLIS = 5000
 
   def isTopicExist(topicName: String): Boolean = {
     val options = new ListTopicsOptions()
@@ -112,20 +105,20 @@ trait BaseKafkaDockerIntegrationTest extends BaseDockerIntegrationTest {
       ()
     }
 
-  def produceRecords(topicName: String, values: Seq[String]): Unit = {
+  def produceRecords[V: ValueSerde](topicName: String, values: Seq[V]): Unit = {
     val properties: Map[String, Object] = Map.of(
       ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-      kafkaBrokerContainer.getBootstrapServers(),
+      getExternalBootstrapServers(),
       ProducerConfig.CLIENT_ID_CONFIG,
       "consumer-group"
     )
-    val producer = new KafkaProducer(
+    val producer = new KafkaProducer[String, V](
       properties,
       new StringSerializer(),
-      new StringSerializer()
+      ValueSerializer[V]
     )
     values.foreach { case value =>
-      producer.send(new ProducerRecord(topicName, "key", value))
+      producer.send(new ProducerRecord[String, V](topicName, "key", value))
     }
     producer.flush()
     producer.close()
@@ -135,16 +128,16 @@ trait BaseKafkaDockerIntegrationTest extends BaseDockerIntegrationTest {
   override def beforeAll(): Unit = {
     super.beforeAll()
     zookeeperContainer.start()
-    schemaRegistryContainer.start()
     kafkaBrokerContainer.start()
-    prepareKafkaCluster()
+    schemaRegistryContainer.start()
+    setupAdminClient()
   }
 
   override def afterAll(): Unit = {
+    adminClient.close()
     zookeeperContainer.stop()
     schemaRegistryContainer.stop()
     kafkaBrokerContainer.stop()
-    adminClient.close()
     super.afterAll()
   }
 

--- a/src/it/scala/com/exasol/cloudetl/kafka/docker/BaseKafkaDockerIntegrationTest.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/docker/BaseKafkaDockerIntegrationTest.scala
@@ -135,9 +135,9 @@ trait BaseKafkaDockerIntegrationTest extends BaseDockerIntegrationTest {
 
   override def afterAll(): Unit = {
     adminClient.close()
-    zookeeperContainer.stop()
     schemaRegistryContainer.stop()
     kafkaBrokerContainer.stop()
+    zookeeperContainer.stop()
     super.afterAll()
   }
 

--- a/src/it/scala/com/exasol/cloudetl/kafka/docker/KafkaContainer.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/docker/KafkaContainer.scala
@@ -1,0 +1,18 @@
+package com.exasol.cloudetl.kafka
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * A Kafka container that exposes a fixed port.
+ *
+ * This is required since [[GenericContainer]] does not provide public API for exposing fixed ports.
+ */
+class KafkaContainer(image: DockerImageName, fixedPort: Int = 29092) extends GenericContainer(image) {
+
+  override def configure(): Unit = {
+    super.configure()
+    addFixedExposedPort(fixedPort, fixedPort)
+  }
+
+}

--- a/src/it/scala/com/exasol/cloudetl/kafka/docker/KafkaImportIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/docker/KafkaImportIT.scala
@@ -5,9 +5,9 @@ import java.sql.Timestamp
 import java.util.UUID
 
 import com.exasol.cloudetl.kafka.serde._
-import com.exasol.cloudetl.kafka.serde.PrimitiveSerdes.Implicits._
-import com.exasol.cloudetl.kafka.serde.AvroSerdes.Implicits._
 import com.exasol.cloudetl.kafka.serde.AvroRecordFormat.Implicits._
+import com.exasol.cloudetl.kafka.serde.AvroSerdes.Implicits._
+import com.exasol.cloudetl.kafka.serde.PrimitiveSerdes.Implicits._
 import com.exasol.dbbuilder.dialects.Table
 import com.exasol.matcher.ResultSetStructureMatcher.table
 import com.exasol.matcher.TypeMatchMode.NO_JAVA_TYPE_CHECK

--- a/src/it/scala/com/exasol/cloudetl/kafka/docker/KafkaImportIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/docker/KafkaImportIT.scala
@@ -1,8 +1,13 @@
 package com.exasol.cloudetl.kafka
 
 import java.sql.ResultSet
+import java.sql.Timestamp
 import java.util.UUID
 
+import com.exasol.cloudetl.kafka.serde._
+import com.exasol.cloudetl.kafka.serde.PrimitiveSerdes.Implicits._
+import com.exasol.cloudetl.kafka.serde.AvroSerdes.Implicits._
+import com.exasol.cloudetl.kafka.serde.AvroRecordFormat.Implicits._
 import com.exasol.dbbuilder.dialects.Table
 import com.exasol.matcher.ResultSetStructureMatcher.table
 import com.exasol.matcher.TypeMatchMode.NO_JAVA_TYPE_CHECK
@@ -33,6 +38,23 @@ class KafkaImportIT extends BaseKafkaDockerIntegrationTest with BeforeAndAfterEa
   override final def afterEach(): Unit = {
     executeStmt(s"DROP TABLE IF EXISTS ${getTableName()}")
     deleteTopic(topicName)
+  }
+
+  test("import longs as timestamp values") {
+    case class TimestampRecord(timestamp: Long)
+    implicit val timestampRecordValueSerde = valueAvroSerde[TimestampRecord](getExternalSchemaRegistryUrl())
+
+    val timestamp = new Timestamp(System.currentTimeMillis())
+    KafkaImportChecker(Map("COLUMN" -> "TIMESTAMP"))
+      .withImportProperties(Map("RECORD_VALUE_FORMAT" -> "avro"))
+      .withTopicValues(Seq(TimestampRecord(0L), TimestampRecord(1337L), TimestampRecord(timestamp.getTime())))
+      .assert(
+        table()
+          .row(new Timestamp(0L), 0L, 0L)
+          .row(new Timestamp(1337L), 0L, 1L)
+          .row(timestamp, 0L, 2L)
+          .matches(NO_JAVA_TYPE_CHECK)
+      )
   }
 
   test("import string values") {
@@ -98,7 +120,7 @@ class KafkaImportIT extends BaseKafkaDockerIntegrationTest with BeforeAndAfterEa
       this
     }
 
-    def withTopicValues(values: Seq[String]): KafkaImportChecker = {
+    def withTopicValues[V: ValueSerde](values: Seq[V]): KafkaImportChecker = {
       produceRecords(topicName, values)
       this
     }
@@ -142,17 +164,19 @@ class KafkaImportIT extends BaseKafkaDockerIntegrationTest with BeforeAndAfterEa
       val rs = executeQuery(s"SELECT * FROM ${getTableName()}")
       block(rs)
       rs.close()
+      ()
     }
   }
 
   private[this] def defaultImportStatement(table: Table): String =
     s"""|IMPORT INTO ${table.getFullyQualifiedName()}
         |FROM SCRIPT $schemaName.KAFKA_CONSUMER WITH
-        |BOOTSTRAP_SERVERS = 'kafka01:9092'
-        |TOPIC_NAME        = '$topicName'
-        |TABLE_NAME        = '${table.getFullyQualifiedName()}'
-        |POLL_TIMEOUT_MS   = '300'
-        |GROUP_ID          = 'exasol-kafka-udf-consumers'
+        |BOOTSTRAP_SERVERS   = 'kafka01:9092'
+        |SCHEMA_REGISTRY_URL = 'http://schema-registry:8081'
+        |TOPIC_NAME          = '$topicName'
+        |TABLE_NAME          = '${table.getFullyQualifiedName()}'
+        |POLL_TIMEOUT_MS     = '300'
+        |GROUP_ID            = 'exasol-kafka-udf-consumers'
     """.stripMargin
 
 }

--- a/src/it/scala/com/exasol/cloudetl/kafka/docker/KafkaImportIT.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/docker/KafkaImportIT.scala
@@ -2,7 +2,7 @@ package com.exasol.cloudetl.kafka
 
 import java.sql.ResultSet
 import java.sql.Timestamp
-import java.util.UUID
+import java.util.{TimeZone, UUID}
 
 import com.exasol.cloudetl.kafka.serde._
 import com.exasol.cloudetl.kafka.serde.AvroRecordFormat.Implicits._
@@ -43,6 +43,8 @@ class KafkaImportIT extends BaseKafkaDockerIntegrationTest with BeforeAndAfterEa
   test("import longs as timestamp values") {
     case class TimestampRecord(timestamp: Long)
     implicit val timestampRecordValueSerde = valueAvroSerde[TimestampRecord](getExternalSchemaRegistryUrl())
+
+    TimeZone.setDefault(exasolContainer.getTimeZone())
 
     val timestamp = new Timestamp(System.currentTimeMillis())
     KafkaImportChecker(Map("COLUMN" -> "TIMESTAMP"))

--- a/src/it/scala/com/exasol/cloudetl/kafka/docker/SchemaRegistryContainer.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/docker/SchemaRegistryContainer.scala
@@ -1,0 +1,16 @@
+package com.exasol.cloudetl.kafka
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * A Schema Registry container that exposes a fixed port.
+ */
+class SchemaRegistryContainer(image: DockerImageName, fixedPort: Int = 8081) extends GenericContainer(image) {
+
+  override def configure(): Unit = {
+    super.configure()
+    addFixedExposedPort(fixedPort, fixedPort)
+  }
+
+}

--- a/src/it/scala/com/exasol/cloudetl/kafka/serde/AvroRecordFormat.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/serde/AvroRecordFormat.scala
@@ -1,0 +1,16 @@
+package com.exasol.cloudetl.kafka.serde
+
+import com.sksamuel.avro4s.Encoder
+import com.sksamuel.avro4s.Decoder
+import com.sksamuel.avro4s.RecordFormat
+import com.sksamuel.avro4s.SchemaFor
+
+trait AvroRecordFormat {
+
+  implicit def avroRecordFormatGeneric[T: Encoder: Decoder: SchemaFor]: RecordFormat[T] = RecordFormat[T]
+
+}
+
+object AvroRecordFormat {
+  object Implicits extends AvroRecordFormat
+}

--- a/src/it/scala/com/exasol/cloudetl/kafka/serde/AvroRecordFormat.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/serde/AvroRecordFormat.scala
@@ -7,7 +7,7 @@ import com.sksamuel.avro4s.SchemaFor
 
 trait AvroRecordFormat {
 
-  implicit def avroRecordFormatGeneric[T: Encoder: Decoder: SchemaFor]: RecordFormat[T] = RecordFormat[T]
+  implicit def avroRecordFormat[T: Encoder: Decoder: SchemaFor]: RecordFormat[T] = RecordFormat[T]
 
 }
 

--- a/src/it/scala/com/exasol/cloudetl/kafka/serde/AvroSerdes.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/serde/AvroSerdes.scala
@@ -1,0 +1,53 @@
+package com.exasol.cloudetl.kafka.serde
+
+import java.util.Map
+
+import com.sksamuel.avro4s.RecordFormat
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.common.serialization.Serializer
+import org.apache.kafka.common.serialization.Deserializer
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
+import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde
+
+trait AvroSerdes {
+
+  implicit def valueAvroSerde[T >: Null](schemaRegistryUrl: String)(implicit
+    recordFormat: RecordFormat[T]
+  ): ValueSerde[T] =
+    kafkaSerde(genericAvroSerde(schemaRegistryUrl, false), recordFormat).asInstanceOf[ValueSerde[T]]
+
+  private[kafka] def kafkaSerde[T >: Null](
+    genericAvroSerde: GenericAvroSerde,
+    recordFormat: RecordFormat[T]
+  ): Serde[T] = Serdes.serdeFrom(
+    new Serializer[T] {
+      override def serialize(topic: String, data: T): Array[Byte] =
+        if (data == null) {
+          null
+        } else {
+          genericAvroSerde.serializer().serialize(topic, recordFormat.to(data))
+        }
+    },
+    new Deserializer[T] {
+      override def deserialize(topic: String, data: Array[Byte]): T =
+        if (data == null) {
+          null
+        } else {
+          recordFormat.from(genericAvroSerde.deserializer().deserialize(topic, data))
+        }
+    }
+  )
+
+  private[kafka] def genericAvroSerde(schemaRegistryUrl: String, isKey: Boolean): GenericAvroSerde = {
+    val serde = new GenericAvroSerde()
+    val properties = Map.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl)
+    serde.configure(properties, isKey)
+    serde
+  }
+
+}
+
+object AvroSerdes {
+  object Implicits extends AvroSerdes
+}

--- a/src/it/scala/com/exasol/cloudetl/kafka/serde/PrimitiveSerdes.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/serde/PrimitiveSerdes.scala
@@ -1,0 +1,15 @@
+package com.exasol.cloudetl.kafka.serde
+
+import org.apache.kafka.common.serialization.Serdes
+
+trait PrimitiveSerdes {
+
+  implicit val stringValueSerde = Serdes.String().asInstanceOf[ValueSerde[String]]
+
+  // Other types (int, long, float, double) can be added similarly when required
+
+}
+
+object PrimitiveSerdes {
+  object Implicits extends PrimitiveSerdes
+}

--- a/src/it/scala/com/exasol/cloudetl/kafka/serde/package.scala
+++ b/src/it/scala/com/exasol/cloudetl/kafka/serde/package.scala
@@ -1,0 +1,16 @@
+package com.exasol.cloudetl.kafka
+
+import org.apache.kafka.common.serialization.Serde
+import org.apache.kafka.common.serialization.Serializer
+
+sealed trait HasValueSerde
+
+package object serde {
+
+  type ValueSerde[T] = Serde[T] with HasValueSerde
+
+  object ValueSerializer {
+    def apply[T](implicit valueSerde: ValueSerde[T]): Serializer[T] = valueSerde.serializer()
+  }
+
+}

--- a/src/main/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporter.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/KafkaTopicDataImporter.scala
@@ -27,6 +27,7 @@ object KafkaTopicDataImporter extends LazyLogging {
     val partitionId = iterator.getInteger(1)
     val partitionNextOffset = iterator.getLong(2) + 1L
     val outputColumnCount = metadata.getOutputColumnCount().toInt
+    val outputColumnTypes: Seq[Class[_]] = (0 until outputColumnCount).map(x => metadata.getOutputColumnType(x))
     val nodeId = metadata.getNodeId()
     val vmId = metadata.getVmId()
     logger.info(
@@ -37,6 +38,7 @@ object KafkaTopicDataImporter extends LazyLogging {
       kafkaProperties,
       partitionId,
       partitionNextOffset,
+      outputColumnTypes,
       outputColumnCount,
       nodeId,
       vmId

--- a/src/main/scala/com/exasol/cloudetl/kafka/consumer/KafkaRecordConsumer.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/consumer/KafkaRecordConsumer.scala
@@ -105,6 +105,7 @@ class KafkaRecordConsumer(
     records: ConsumerRecords[FieldType, FieldType]
   ): Long = {
     var lastRecordOffset = -1L
+    val fieldConverter = new FieldConverter(outputColumnTypes)
     records.asScala.foreach { record =>
       lastRecordOffset = record.offset()
       val metadata: Seq[Object] = Seq(
@@ -114,7 +115,7 @@ class KafkaRecordConsumer(
       val columnsCount = tableColumnCount - metadata.size
       val rowValues = RowBuilder.buildRow(recordFieldSpecifications, record, columnsCount)
       val row: Seq[Any] = rowValues ++ metadata
-      val converted_row: Seq[Any] = new FieldConverter(outputColumnTypes).convertRow(row)
+      val converted_row: Seq[Any] = fieldConverter.convertRow(row)
       iterator.emit(converted_row: _*)
     }
     lastRecordOffset

--- a/src/main/scala/com/exasol/cloudetl/kafka/consumer/KafkaRecordConsumer.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/consumer/KafkaRecordConsumer.scala
@@ -115,8 +115,8 @@ class KafkaRecordConsumer(
       val columnsCount = tableColumnCount - metadata.size
       val rowValues = RowBuilder.buildRow(recordFieldSpecifications, record, columnsCount)
       val row: Seq[Any] = rowValues ++ metadata
-      val converted_row: Seq[Any] = fieldConverter.convertRow(row)
-      iterator.emit(converted_row: _*)
+      val convertedRow: Seq[Any] = fieldConverter.convertRow(row)
+      iterator.emit(convertedRow: _*)
     }
     lastRecordOffset
   }

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
@@ -3,6 +3,9 @@ package com.exasol.cloudetl.kafka.deserialization
 import java.lang.{Long => JLong}
 import java.sql.Timestamp
 
+/**
+ * A class that converts a long value to timestamp if required by the Exasol column output type
+ */
 class FieldConverter(outputColumnTypes: Seq[Class[_]]) {
 
   final def convertRow(row: Seq[Any]): Seq[Any] =

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
@@ -1,5 +1,6 @@
 package com.exasol.cloudetl.kafka.deserialization
 
+import java.lang.{Long => JLong}
 import java.sql.Timestamp
 
 class FieldConverter(
@@ -11,7 +12,7 @@ class FieldConverter(
 
   final def convert(columnType: Class[_], value: Any): Any =
     value match {
-      case x: Long if columnType == classOf[Timestamp] => new Timestamp(x)
-      case _                                           => value
+      case x: JLong if columnType == classOf[Timestamp] => new Timestamp(x)
+      case _                                            => value
     }
 }

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
@@ -1,0 +1,23 @@
+package com.exasol.cloudetl.kafka.deserialization
+
+import java.sql.{Date, Timestamp}
+
+class FieldConverter(
+  outputColumnTypes: Seq[Class[_]]
+) {
+
+  final def convertRow(row: Seq[Any]): Seq[Any] = {
+    row.zipWithIndex map (x => convert(outputColumnTypes(x._2), x._1))
+  }
+
+  final def convert(column_type: Class[_], value: Any): Any = {
+    if (column_type == classOf[Timestamp]) {
+      value match {
+        case x: Long => new Timestamp(x)
+        case _ => value
+      }
+    } else {
+      value
+    }
+  }
+}

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
@@ -1,23 +1,17 @@
 package com.exasol.cloudetl.kafka.deserialization
 
-import java.sql.{Date, Timestamp}
+import java.sql.Timestamp
 
 class FieldConverter(
   outputColumnTypes: Seq[Class[_]]
 ) {
 
-  final def convertRow(row: Seq[Any]): Seq[Any] = {
-    row.zipWithIndex map (x => convert(outputColumnTypes(x._2), x._1))
-  }
+  final def convertRow(row: Seq[Any]): Seq[Any] =
+    row.zipWithIndex.map(x => convert(outputColumnTypes(x._2), x._1))
 
-  final def convert(column_type: Class[_], value: Any): Any = {
-    if (column_type == classOf[Timestamp]) {
-      value match {
-        case x: Long => new Timestamp(x)
-        case _ => value
-      }
-    } else {
-      value
+  final def convert(column_type: Class[_], value: Any): Any =
+    value match {
+      case x: Long if column_type == classOf[Timestamp] => new Timestamp(x)
+      case _                                            => value
     }
-  }
 }

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
@@ -9,9 +9,9 @@ class FieldConverter(
   final def convertRow(row: Seq[Any]): Seq[Any] =
     row.zipWithIndex.map(x => convert(outputColumnTypes(x._2), x._1))
 
-  final def convert(column_type: Class[_], value: Any): Any =
+  final def convert(columnType: Class[_], value: Any): Any =
     value match {
-      case x: Long if column_type == classOf[Timestamp] => new Timestamp(x)
-      case _                                            => value
+      case x: Long if columnType == classOf[Timestamp] => new Timestamp(x)
+      case _                                           => value
     }
 }

--- a/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
+++ b/src/main/scala/com/exasol/cloudetl/kafka/deserialization/FieldConverter.scala
@@ -3,9 +3,7 @@ package com.exasol.cloudetl.kafka.deserialization
 import java.lang.{Long => JLong}
 import java.sql.Timestamp
 
-class FieldConverter(
-  outputColumnTypes: Seq[Class[_]]
-) {
+class FieldConverter(outputColumnTypes: Seq[Class[_]]) {
 
   final def convertRow(row: Seq[Any]): Seq[Any] =
     row.zipWithIndex.map(x => convert(outputColumnTypes(x._2), x._1))
@@ -15,4 +13,5 @@ class FieldConverter(
       case x: JLong if columnType == classOf[Timestamp] => new Timestamp(x)
       case _                                            => value
     }
+
 }

--- a/src/test/scala/com/exasol/cloudetl/kafka/consumer/KafkaRecordConsumerTest.scala
+++ b/src/test/scala/com/exasol/cloudetl/kafka/consumer/KafkaRecordConsumerTest.scala
@@ -164,7 +164,15 @@ class KafkaRecordConsumerTest extends AnyFunSuite with BeforeAndAfterEach with M
   }
 
   case class TestKafkaRecordConsumer(properties: KafkaConsumerProperties, startOffset: Long)
-      extends KafkaRecordConsumer(properties, 0, startOffset, 3, 1L, "vm1") {
+      extends KafkaRecordConsumer(
+        properties,
+        0,
+        startOffset,
+        Seq(classOf[String], classOf[Long], classOf[Long]),
+        3,
+        1L,
+        "vm1"
+      ) {
     override final def getRecordConsumer(): KafkaConsumer[FieldType, FieldType] = consumer
   }
 


### PR DESCRIPTION
Adding the ability to use TIMESTAMP as the output column type for any field containing milliseconds Unix epoch timestamp (incl. message timestamp).

It was previously impossible to use TIMESTAMP as output column type
```sql
CREATE SCHEMA RND;

CREATE OR REPLACE TABLE RND.TEST_KAFKA_TIMESTAMP (
  DTTM TIMESTAMP,
  JSON VARCHAR(2000000),
  KAFKA_PARTITION DECIMAL(18, 0),
  KAFKA_OFFSET    DECIMAL(36, 0)
);

IMPORT INTO RND.TEST_KAFKA_TIMESTAMP (DTTM, JSON, KAFKA_PARTITION, KAFKA_OFFSET)
FROM SCRIPT KAFKA_EXTENSION.KAFKA_CONSUMER
WITH
 BOOTSTRAP_SERVERS = 'kafka-01:9092'
 TOPIC_NAME = 'test_topic'
 RECORD_FIELDS = 'timestamp,value'
 TABLE_NAME = 'RND.TEST_KAFKA_TIMESTAMP'
 RECORD_VALUE_FORMAT = 'string'
 GROUP_ID = 'exasol-kafka-test'
;
```
results in an error
```
[2021-08-25 16:21:15] [22002] VM error: F-UDF-CL-LIB-1127: F-UDF-CL-SL-JAVA-1002: F-UDF-CL-SL-JAVA-1013:
[2021-08-25 16:21:15] com.exasol.ExaUDFException: F-UDF-CL-SL-JAVA-1080: Exception during run
[2021-08-25 16:21:15] com.exasol.cloudetl.kafka.KafkaConnectorException: Error consuming Kafka topic 'test_topic' data. It occurs for partition '1' in node '0' and vm '139980029142784' Cause: E-UDF-CL-SL-JAVA-1109: emit column 'DTTM' is of type TIMESTAMP but data given have type java.lang.Long
[2021-08-25 16:21:15] com.exasol.cloudetl.kafka.consumer.KafkaRecordConsumer.emit(KafkaRecordConsumer.scala:64)
[2021-08-25 16:21:15] com.exasol.cloudetl.kafka.KafkaTopicDataImporter$.run(KafkaTopicDataImporter.scala:43)
[2021-08-25 16:21:15] com.exasol.cloudetl.kafka.KafkaTopicDataImporter.run(KafkaTopicDataImporter.scala)
[2021-08-25 16:21:15] com.exasol.ExaWrapper.run(ExaWrapper.java:196)
[2021-08-25 16:21:15] Caused by: com.exasol.ExaDataTypeException: E-UDF-CL-SL-JAVA-1109: emit column 'DTTM' is of type TIMESTAMP but data given have type java.lang.Long
[2021-08-25 16:21:15] com.exasol.ExaIteratorImpl.emit(ExaIteratorImpl.java:124)
[2021-08-25 16:21:15] com.exasol.cloudetl.kafka.consumer.KafkaRecordConsumer.$anonfun$emitRecords$1(KafkaRecordConsumer.scala:110)
[2021-08-25 16:21:15] com.exasol.cloudetl.kafka.consumer.KafkaRecordConsumer.$anonfun$emitRecords$1$adapted(KafkaRecordConsumer.scala:101)
[2021-08-25 16:21:15] scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
[2021-08-25 16:21:15] scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
[2021-08-25 16:21:15] scala.collection.AbstractIterable.foreach(Iterable.scala:919)
[2021-08-25 16:21:15] com.exasol.cloudetl.kafka.consumer.KafkaRecordConsumer.emitRecords(KafkaRecordConsumer.scala:101)
[2021-08-25 16:21:15] com.exasol.cloudetl.kafka.consumer.KafkaRecordConsumer.emit(KafkaRecordConsumer.scala:52)
[2021-08-25 16:21:15] 	... 7 more
```